### PR TITLE
Fixing option "-o" to display numerical OIDs.

### DIFF
--- a/src/docsis.c
+++ b/src/docsis.c
@@ -189,6 +189,9 @@ main (int argc, char *argv[])
 
   if (!strcmp (argv[1], "-o") ){
 	resolve_oids = 0;
+	  if (!netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID, NETSNMP_OID_OUTPUT_NUMERIC)) {
+		  netsnmp_ds_toggle_boolean (NETSNMP_DS_LIBRARY_ID, NETSNMP_OID_OUTPUT_NUMERIC);
+	  }
 	if (!strcmp (argv[2], "-d")) {
 		decode_bin = TRUE;
 		config_file = argv[3];
@@ -464,7 +467,7 @@ setup_mib_flags(int resolve_oids, char *custom_mibs) {
 #else
   init_mib ();
 #endif
-
+  
   if (!netsnmp_ds_get_boolean
       (NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_PRINT_NUMERIC_OIDS))
     {

--- a/src/docsis_snmp.c
+++ b/src/docsis_snmp.c
@@ -341,6 +341,11 @@ decode_vbind (unsigned char *data, unsigned int vb_len)
 			      NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
 			      NETSNMP_OID_OUTPUT_SUFFIX);
 
+  if (netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID, NETSNMP_OID_OUTPUT_NUMERIC)) {
+        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                                                  NETSNMP_OID_OUTPUT_NUMERIC);
+  }
+
   snprint_objid (outbuf, 1023, vp->name, vp->name_length);
 
   if (!get_node (outbuf, var_name, &name_len))


### PR DESCRIPTION
Before this option "-o" was only not loading the MIBs. Now it is only numerical also.

Closes rlaager/docsis#18.