### PR TITLE
Fix cli parsing

### DIFF
--- a/src/docsis.c
+++ b/src/docsis.c
@@ -261,36 +261,38 @@ usage ()
   fprintf(stderr, "Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL, docsis@evvolve.com\n");
   fprintf(stderr, "Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com\n\n");
 
-  fprintf(stderr, "To encode a cable modem configuration file: \n\tdocsis -e <modem_cfg_file> <key_file> <output_file>\n");
-  fprintf(stderr, "To encode multiple cable modem configuration files: \n\tdocsis -m <modem_cfg_file1> ...  <key_file> <new_extension>\n");
-  fprintf(stderr, "To encode a MTA configuration file: \n\tdocsis -p <mta_cfg_file> <output_file>\n");
-  fprintf(stderr, "To encode multiple MTA configuration files: \n\tdocsis -m -p <mta_file1> ...  <new_extension>\n");
-  fprintf(stderr, "To decode a CM or MTA config file: \n\tdocsis -d <binary_file>\n");
-  fprintf(stderr, "To decode a CM or MTA config file with OIDs: \n\tdocsis -o -d <binary_file>\n");
-  fprintf(stderr, "\nTo specify the MIBPATH encode or decode use:\n"
-		  "\tdocsis -M \"PATH1:PATH2\" -d <binary_file>\n"
-		  "\tdocsis -M \"PATH1:PATH2\" -e <modem_cfg_file> <key_file> <output_file>\n"
-		  "\tdocsis -M \"PATH1:PATH2\" -m <modem_cfg_file1> ...  <key_file> <new_extension>\n"
-		  "\tdocsis -M \"PATH1:PATH2\" -p <mta_cfg_file> <output_file>\n"
-		  "\tdocsis -M \"PATH1:PATH2\" -m -p <mta_file1> ...  <new_extension>\n");
-  fprintf(stderr, "\nTo add SHA1 hash to mta config file, use -na or -eu options:\n");
-  fprintf(stderr, "\tdocsis -na|-eu -p <mta_cfg_file> <output_file>\n");
-  fprintf(stderr, "\tdocsis -na|-eu -m -p <mta_file1> ...  <new_extension>\n");
-  fprintf(stderr, "\nTo add PC20 dialplan from external dialplan.txt file, use -dialplan option:\n");
-  fprintf(stderr, "\tdocsis -p -dialplan <mta_cfg_file> <output_file>\n");
-  fprintf(stderr, "\tdocsis -na|-eu -p -dialplan <mta_cfg_file> <output_file>\n");
-  fprintf(stderr, "\nTo remove hash from MTA config file, use -nohash option:\n");
-  fprintf(stderr, "\tdocsis -nohash -d <mta_cfg_file>\n");
-  fprintf(stderr, "\tdocsis -nohash -o -d <mta_cfg_file>\n");
-  fprintf(stderr, "\nWhere:\n<cfg_file>\t\t= name of text (human readable) cable modem or MTA \n"
+  fprintf(stderr, "To encode a cable modem configuration file: \n\tdocsis [modifiers] -e <modem_cfg_file> <key_file> <output_file>\n");
+  fprintf(stderr, "To encode multiple cable modem configuration files: \n\tdocsis [modifiers] -m <modem_cfg_file1> ... <key_file> <new_extension>\n");
+  fprintf(stderr, "To encode a MTA configuration file: \n\tdocsis [modifiers] -p <mta_cfg_file> <output_file>\n");
+  fprintf(stderr, "To encode multiple MTA configuration files: \n\tdocsis [modifiers] -m -p <mta_file1> ... <new_extension>\n");
+  fprintf(stderr, "To decode a CM or MTA config file: \n\tdocsis [modifiers] -d <binary_file>\n\n");
+
+  fprintf(stderr, "Where:\n<cfg_file>\t\t= name of text (human readable) cable modem or MTA \n"
 		  "\t\t\t  configuration file;\n"
 		  "<key_file>\t\t= text file containing the authentication key\n"
 		  "\t\t\t  (shared secret) to be used for the CMTS MIC;\n"
 		  "<output_file> \t\t= name of output file where"
 		  " the binary data will\n\t\t\t  be written to (if it does not exist it is created);\n"
 		  "<binary_file>\t\t= name of binary file to be decoded;\n"
-		  "<new_extension>\t\t= new extension to be used when encoding multiple files.\n");
-  fprintf(stderr, "\nSee examples/*.cfg for configuration file format.\n");
+		  "<new_extension>\t\t= new extension to be used when encoding multiple files.\n\n");
+
+  fprintf(stderr, "The following command-line modifiers are available:\n"
+	"	-o\n"
+	"		Decode OIDs numerically.\n\n"
+	"	-M \"PATH1:PATH2\"\n"
+	"		Specify the SNMP MIB directory when encoding or decoding configuration\n"
+	"		files.\n\n"
+	"	-na | -eu\n"
+	"		Adds CableLabs PacketCable or Excentis EuroPacketCable SHA1 hash\n"
+	"		when encoding an MTA config file.\n\n"
+	"	-dialplan\n"
+	"		Adds a PC20 dialplan from an external file called \"dialplan.txt\" in\n"
+	"		the current directory.\n\n"
+	"	-nohash\n"
+	"		Removes the PacketCable SHA1 hash from the MTA config file when\n"
+	"		decoding.\n"
+	);
+  fprintf(stderr, "\nSee examples/*.cfg for sample configuration files.\n");
   fprintf(stderr, "\nPlease report bugs or feature requests on GitHub.");
   fprintf(stderr, "\nProject repository is https://github.com/rlaager/docsis\n\n");
   exit (-10);


### PR DESCRIPTION
The current CLI parsing code is spaghetti.  This fixes it up so that it's now clear how it works and so that it is possible to add in new CLI commands and modifiers.