### PR TITLE
-nohash printed both the commented and uncommented hashes

### DIFF
--- a/src/docsis_decode.c
+++ b/src/docsis_decode.c
@@ -313,6 +313,7 @@ void decode_snmp_object (unsigned char *tlvbuf, symbol_type *sym, size_t length 
       decode_vbind (tlvbuf, length );
       printf(" */");
       printf("\n");
+      goto bailout;
     }
     memcpy (pk, "\x30\x24\x06\x0c\x2b\x06\x01\x04\x01\xba\x08\x01\x01\x02\x09", 15);
     memcpy (pl, tlvbuf, 15);
@@ -322,6 +323,7 @@ void decode_snmp_object (unsigned char *tlvbuf, symbol_type *sym, size_t length 
       decode_vbind (tlvbuf, length );
       printf(" */");
       printf("\n");
+      goto bailout;
     }
   }
 
@@ -361,6 +363,9 @@ void decode_snmp_object (unsigned char *tlvbuf, symbol_type *sym, size_t length 
     decode_vbind (tlvbuf, length );
     printf("\n");
   }
+
+  bailout:
+
   free(pi);
   free(pj);
   free(pk);


### PR DESCRIPTION
The -nohash CLI argument printed out both the commented and uncommented hashes.  This patch fixes that.  goto is used instead of nested if() statement because it's cleaner and makes the program flow easier to understand.