### PR TITLE
Fix generate-settings.sh

### DIFF
--- a/doc/generate-settings.sh
+++ b/doc/generate-settings.sh
@@ -30,7 +30,7 @@ cat > $1 << EOF
 EOF
 
 grep -e "^{" ../src/docsis_symtable.h \
-	| grep -v "*" \
+	| grep -v "\"/\*" \
 	| grep -v "decode_md5" \
 	| awk '{print $5 "_" $3 " " $7 " " $8 " " $9}' \
 	| sed 's/\"//g' \


### PR DESCRIPTION
Modify call to `grep -v "*"` in generate-settings.sh which was unintentionally filtering out all symbols from `src/docsis_symtable.h`.