### PR TITLE
Don't print to stderr if encoding succeeds

### DIFF
--- a/src/docsis.c
+++ b/src/docsis.c
@@ -125,9 +125,9 @@ add_cmts_mic (unsigned char *tlvbuf, unsigned int tlvbuflen,
 	    }
 	}
     }
-  fprintf (stderr, "##### Calculating CMTS MIC using TLVs:\n");
+  fprintf (stdout, "##### Calculating CMTS MIC using TLVs:\n");
   decode_main_aggregate (cmts_tlvs, dp - cmts_tlvs);
-  fprintf (stderr, "##### End of CMTS MIC TLVs\n");
+  fprintf (stdout, "##### End of CMTS MIC TLVs\n");
   hmac_md5 (cmts_tlvs, dp - cmts_tlvs, key, keylen, digest);
   md5_print_digest (digest);
   tlvbuf[tlvbuflen] = 7;	/* CMTS MIC */
@@ -561,7 +561,7 @@ int encode_one_file ( char *input_file, char *output_file,
     buflen = add_mta_hash (buffer, buflen, hash);
   }
 
-  fprintf (stderr, "Final content of config file:\n");
+  fprintf (stdout, "Final content of config file:\n");
 
   decode_main_aggregate (buffer, buflen);
   if (!strcmp (output_file, "-"))

--- a/src/hmac_md5.c
+++ b/src/hmac_md5.c
@@ -35,10 +35,10 @@ void md5_print_digest ( unsigned char *digest )
 {
   int j;
   /* TODO check that the buffer actually contains 16 chars ... */
-  fprintf(stderr, " --- MD5 DIGEST: 0x");
+  fprintf(stdout, " --- MD5 DIGEST: 0x");
   for (j=0;j<16;j++)
-	fprintf(stderr, "%02x", digest[j] );
-  fprintf(stderr, "\n");
+	fprintf(stdout, "%02x", digest[j] );
+  fprintf(stdout, "\n");
 }
 
 /*


### PR DESCRIPTION
It is usually considered bad form to print to stderr unless an error actually occured, and some scripting languages will consider a command to have failed if stderr isn't empty.  This tool currently prints the following text to stderr when a modem configuration is successfully encoded:

```
$ docsis -e - delme keyfile delme2 > /dev/null
##### Calculating CMTS MIC using TLVs:
##### End of CMTS MIC TLVs
 --- MD5 DIGEST: 0xf90e368f5d979a2d5093bbaba37f1497
Final content of config file:
```

This PR changes these lines to instead print to stdout so that stderr is empty when the encoding succeeds.