### PR TITLE
version 0.9.9 /proposal/:

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Adrian Simionov <daniel.simionov@gmail.com>
 Cornel Ciocirlan <ctrl@users.sourceforge.net>
 The Evvolve Team <docsis@evvolve.com>
+Lukasz Sierzega <xarafaxz@gmail.com>
 
 Help and feedback received from:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+version 0.9.9 /proposal/:
+	* Feature: Allowing use MIB-MODULE-NAME:: MODULE-NAME-SPACE:: et cetera in SnmpMibObject TLV which i strongly recommend
+		that resolve problems with mibs name colision, for example: PacketCable/EuroPacketCable, Motorola/Compal enterprise mibs.
+		you can use "-f" switch to include MIB-MODULE-NAME:: prefixes in config dump
+	* Feature: Allowing use C-style inline comments "//"
+	* Feature: Allow use custom mib for packetcable hash signing becasuse "-eu" / EuroPacketCable and "-na" PacketCable are not enough
+		use "-H [MIB]" switch to set custom hash mib.
+	* Attempt to cleanup option parsing mess. Now option parsing is getopt based. However due to preserving option compatibility it is create another mess. Just slighty lesser, i think.
+
 version 0.9.8 (??/??/????):
 	* Massive improvements by Adrian Simionov
 

--- a/src/docsis.c
+++ b/src/docsis.c
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,12 +26,15 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H  */
 
+#include <getopt.h>
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
+#include <ctype.h>
 
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/config_api.h>
@@ -48,6 +52,12 @@ struct tlv *global_tlvtree_head;
 symbol_type *global_symtable;
 unsigned int nohash = 0;
 unsigned int dialplan = 0;
+
+char *mta_hash = NULL;
+int mib_warning_level = 1;
+
+char *default_na_hash = "1.3.6.1.4.1.4491.2.2.1.1.2.7.0";
+char *default_eu_hash = "1.3.6.1.4.1.7432.1.1.2.9.0";
 
 static void setup_mib_flags(int resolve_oids, char *custom_mibs);
 
@@ -68,77 +78,15 @@ add_cm_mic (unsigned char *tlvbuf, unsigned int tlvbuflen)
   memcpy (tlvbuf + tlvbuflen + 2, digest, 16);
   return (tlvbuflen + 18);	/* we added the CM Message Integrity Check  */
 }
-
+/* ADD MTA-HASH*/
 static unsigned int
-add_eod_and_pad (unsigned char *tlvbuf, unsigned int tlvbuflen)
+add_mta_hash (unsigned char *tlvbuf, unsigned int tlvbuflen)
 {
-  int nr_pads;
+  unsigned char *buffer;
+  char hash[SHA_DIGEST_LENGTH*2], mtahash[200];
+  int parse_result=0, i=0;
+  unsigned int buflen;
 
-  if (tlvbuf == NULL || tlvbuflen == 0)
-	return 0;
-
-  tlvbuf[tlvbuflen] = 255;
-  tlvbuflen = tlvbuflen + 1;
-  nr_pads = (4 - (tlvbuflen % 4)) % 4;
-  memset (&tlvbuf[tlvbuflen], 0, nr_pads);
-  return (tlvbuflen + nr_pads);
-}
-
-static unsigned int
-add_cmts_mic (unsigned char *tlvbuf, unsigned int tlvbuflen,
-	      unsigned char *key, int keylen)
-{
-
-  int i;
-  register unsigned char *cp, *dp;
-  unsigned char *cmts_tlvs;
-  unsigned char digest[17];
-
-/* Only these configuration TLVs must be used to calculate the CMTS MIC */
-#define NR_CMTS_MIC_TLVS 21
-  unsigned char digest_order[NR_CMTS_MIC_TLVS] =
-    { 1, 2, 3, 4, 17, 43, 6, 18, 19, 20, 22, 23, 24, 25, 28, 29, 26, 35, 36, 37, 40 };
-
-  if (tlvbuf == NULL || tlvbuflen == 0 )
-	return 0;
-
-  cmts_tlvs = (unsigned char *) malloc (tlvbuflen + 1); /* Plenty of space */
-  dp = cmts_tlvs;
-  for (i = 0; i < NR_CMTS_MIC_TLVS; i++)
-    {
-      cp = tlvbuf;
-      while ((unsigned int) (cp - tlvbuf) < tlvbuflen)
-	{
-	  if (cp[0] == digest_order[i])
-	    {
-	      memcpy (dp, cp, cp[1] + 2);
-	      dp = dp + cp[1] + 2;
-	      cp = cp + cp[1] + 2;
-	    }
-	  else
-	    {
-	      if ( cp[0] == 64 ) {
-		cp = cp + (size_t) ntohs(*((unsigned short *)(cp+1))) + 3;
-	      } else {
-	      	cp = cp + cp[1] + 2;
-	      }
-	    }
-	}
-    }
-  fprintf (stdout, "##### Calculating CMTS MIC using TLVs:\n");
-  decode_main_aggregate (cmts_tlvs, dp - cmts_tlvs);
-  fprintf (stdout, "##### End of CMTS MIC TLVs\n");
-  hmac_md5 (cmts_tlvs, dp - cmts_tlvs, key, keylen, digest);
-  md5_print_digest (digest);
-  tlvbuf[tlvbuflen] = 7;	/* CMTS MIC */
-  tlvbuf[tlvbuflen + 1] = 16;	/* length of MD5 digest */
-  memcpy (&tlvbuf[tlvbuflen + 2], digest, 16);
-  free (cmts_tlvs);
-  return (tlvbuflen + 18);
-}
-
-static unsigned int
-add_mta_hash (unsigned char *tlvbuf, unsigned int tlvbuflen, unsigned int hash) {
   SHA_CTX shactx;
   unsigned char hash_value[SHA_DIGEST_LENGTH];
 
@@ -146,21 +94,47 @@ add_mta_hash (unsigned char *tlvbuf, unsigned int tlvbuflen, unsigned int hash) 
   SHA1_Update(&shactx, tlvbuf, tlvbuflen);
   SHA1_Final(hash_value, &shactx);
 
-  if (hash == 1) {
-    memcpy (tlvbuf + tlvbuflen - 3, "\x0b\x28\x30\x26\x06\x0e\x2b\x06\x01\x04\x01\xa3\x0b\x02\x02\x01\x01\x02\x07\x00\x04\x14", 22);
-    tlvbuflen += 19;
-  }
-  if (hash == 2) {
-    memcpy (tlvbuf + tlvbuflen - 3, "\x0b\x26\x30\x24\x06\x0c\x2b\x06\x01\x04\x01\xba\x08\x01\x01\x02\x09\x00\x04\x14", 20);
-    tlvbuflen += 17;
+  //generate hash  
+  memset(hash, 0x0, SHA_DIGEST_LENGTH*2);
+  
+  for (i=0; i < SHA_DIGEST_LENGTH; i++) 
+  {
+  	  sprintf((char*)&(hash[i*2]), "%02x", hash_value[i]);
   }
 
-  memcpy (tlvbuf + tlvbuflen, hash_value, SHA_DIGEST_LENGTH);
-  tlvbuflen += SHA_DIGEST_LENGTH;
-  memcpy (tlvbuf + tlvbuflen, "\xfe\x01\xff", 3);
+  //generate config-setting
+  sprintf(mtahash, "Main\n{\n\tSnmpMibObject %s HexString 0x%s ;\n}\n", mta_hash, hash);
+
+  //compile config-setting
+  parse_result = parse_config_file ("", &global_tlvtree_head, mtahash );
+
+  if (parse_result || global_tlvtree_head == NULL)
+  {
+  	  fprintf(stderr, "Error parsing hash string %s\n", mtahash);
+  	  return -1;
+  }
+
+  buflen = tlvtreelen (global_tlvtree_head);
+  buffer = (unsigned char *) malloc ( buflen + 255 );
+  buflen = flatten_tlvsubtree(buffer, 0, global_tlvtree_head);
+
+#ifdef DEBUG
+  printf("SNMP is: %s - length=%d\n", mtahash, buflen);
+  decode_main_aggregate (buffer, buflen);
+#endif /* DEBUG */
+
+  //replacing "MtaConfigDelimiter 255"
+  tlvbuflen -= 3;
+  memcpy (tlvbuf + tlvbuflen , buffer, buflen);
+  tlvbuflen += buflen;
+
+  //adding "MtaConfigDelimiter 255"
+  tlvbuf[tlvbuflen] = 254;
+  tlvbuf[tlvbuflen + 1] = 1;
+  tlvbuf[tlvbuflen + 2] = 255;
   tlvbuflen += 3;
 
-  return (tlvbuflen);
+  return (tlvbuflen);      /* we have added the MTA-HASH  */
 }
 
 static unsigned int
@@ -249,6 +223,75 @@ add_dialplan (unsigned char *tlvbuf, unsigned int tlvbuflen) {
   return (tlvbuflen);
 }
 
+static unsigned int
+add_eod_and_pad (unsigned char *tlvbuf, unsigned int tlvbuflen)
+{
+  int nr_pads;
+
+  if (tlvbuf == NULL || tlvbuflen == 0)
+	return 0;
+
+  tlvbuf[tlvbuflen] = 255;
+  tlvbuflen = tlvbuflen + 1;
+  nr_pads = (4 - (tlvbuflen % 4)) % 4;
+  memset (&tlvbuf[tlvbuflen], 0, nr_pads);
+  return (tlvbuflen + nr_pads);
+}
+
+static unsigned int
+add_cmts_mic (unsigned char *tlvbuf, unsigned int tlvbuflen,
+	      unsigned char *key, int keylen)
+{
+
+  int i;
+  register unsigned char *cp, *dp;
+  unsigned char *cmts_tlvs;
+  unsigned char digest[17];
+
+/* Only these configuration TLVs must be used to calculate the CMTS MIC */
+#define NR_CMTS_MIC_TLVS 21
+  unsigned char digest_order[NR_CMTS_MIC_TLVS] =
+    { 1, 2, 3, 4, 17, 43, 6, 18, 19, 20, 22, 23, 24, 25, 28, 29, 26, 35, 36, 37, 40 };
+
+  if (tlvbuf == NULL || tlvbuflen == 0 )
+	return 0;
+
+  cmts_tlvs = (unsigned char *) malloc (tlvbuflen + 1); /* Plenty of space */
+  dp = cmts_tlvs;
+  for (i = 0; i < NR_CMTS_MIC_TLVS; i++)
+    {
+      cp = tlvbuf;
+      while ((unsigned int) (cp - tlvbuf) < tlvbuflen)
+	{
+	  if (cp[0] == digest_order[i])
+	    {
+	      memcpy (dp, cp, cp[1] + 2);
+	      dp = dp + cp[1] + 2;
+	      cp = cp + cp[1] + 2;
+	    }
+	  else
+	    {
+	      if ( cp[0] == 64 ) {
+		fprintf(stderr, "docsis: warning: TLV64 (length > 255) not allowed in DOCSIS config files\n");
+		cp = cp + (size_t) ntohs(*((unsigned short *)(cp+1))) + 3;
+	      } else {
+	      	cp = cp + cp[1] + 2;
+	      }
+	    }
+	}
+    }
+  fprintf (stderr, "##### Calculating CMTS MIC using TLVs:\n");
+  decode_main_aggregate (cmts_tlvs, dp - cmts_tlvs);
+  fprintf (stderr, "##### End of CMTS MIC TLVs\n");
+  hmac_md5 (cmts_tlvs, dp - cmts_tlvs, key, keylen, digest);
+  md5_print_digest (digest);
+  tlvbuf[tlvbuflen] = 7;	/* CMTS MIC */
+  tlvbuf[tlvbuflen + 1] = 16;	/* length of MD5 digest */
+  memcpy (&tlvbuf[tlvbuflen + 2], digest, 16);
+  free (cmts_tlvs);
+  return (tlvbuflen + 18);
+}
+
 #ifdef __GNUC__
 static void usage () __attribute__((__noreturn__));
 #endif
@@ -259,7 +302,8 @@ usage ()
   fprintf(stderr, "DOCSIS Configuration File creator, version %s\n", VERSION);
   fprintf(stderr, "Copyright (c) 1999,2000,2001 Cornel Ciocirlan, ctrl@users.sourceforge.net\n");
   fprintf(stderr, "Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL, docsis@evvolve.com\n");
-  fprintf(stderr, "Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com\n\n");
+  fprintf(stderr, "Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com\n");
+  fprintf(stderr, "Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com\n\n");
 
   fprintf(stderr, "To encode a cable modem configuration file: \n\tdocsis [modifiers] -e <modem_cfg_file> <key_file> <output_file>\n");
   fprintf(stderr, "To encode multiple cable modem configuration files: \n\tdocsis [modifiers] -m <modem_cfg_file1> ... <key_file> <new_extension>\n");
@@ -291,12 +335,21 @@ usage ()
 	"	-nohash\n"
 	"		Removes the PacketCable SHA1 hash from the MTA config file when\n"
 	"		decoding.\n"
+	"	-f\n"
+	"		Include MIB-MODULE-NAME:: prefix when decoding/dumping\n"
+	"	-H\n"
+	"		Use custom MIB for PacketCable config hash:\n"
+	"		Example: -H PKTC-IETF-MTA-MIB::pktcMtaDevProvConfigHash.0, \n"
+	"			-H 1.3.6.1.2.1.140.1.2.11.0 \n"
+	"	-w	[integer]\n"
+	"		Set mib warning mode:\n"
 	);
   fprintf(stderr, "\nSee examples/*.cfg for sample configuration files.\n");
   fprintf(stderr, "\nPlease report bugs or feature requests on GitHub.");
   fprintf(stderr, "\nProject repository is https://github.com/rlaager/docsis\n\n");
   exit (-10);
 }
+
 
 int
 main (int argc, char *argv[])
@@ -305,201 +358,172 @@ main (int argc, char *argv[])
   FILE *kf;
   char *config_file=NULL, *key_file=NULL, *output_file=NULL, *extension_string=NULL, *custom_mibs=NULL;
   unsigned int keylen = 0;
-  unsigned int encode_docsis = FALSE, decode_bin = FALSE, hash = 0;
+  unsigned int encode_docsis = FALSE, decode_bin = FALSE, process_multiple = FALSE;
+  char c;
   int i;
   int resolve_oids = 1;
 
-  while (argc > 0) {
-    argc--; argv++;
-
-    if (!argc) {
-      usage();
-    }
-
-    /* the initial command-line parameters are flags / modifiers */
-    if (!strcmp (argv[0], "-nohash")) {
-      nohash = 1;
-
-      continue;
-    }
-
-    if (!strcmp (argv[0], "-o")) {
-      resolve_oids = 0;
-      continue;
-    }
-
-    if (!strcmp (argv[0], "-M")) {
-      if (argc < 2 ) {
-        usage();
-      }
-
-      custom_mibs=argv[1];
-
-      argc--; argv++;
-      continue;
-    }
-
-    if (!strcmp (argv[0], "-na")) {
-      if (hash) {
-        usage();
-      }
-      hash = 1;
-      continue;
-    }
-
-    if (!strcmp (argv[0], "-eu")) {
-      if (hash) {
-        usage();
-      }
-      hash = 2;
-      continue;
-    }
-
-    if (!strcmp (argv[0], "-dialplan")) {
-      dialplan = 1;
-      continue;
-    }
-
-    /* the following command-line parameters are actions */
-
-    if (!strcmp (argv[0], "-d")) {
-      if (argc < 2 ) {
-        usage();
-      }
-
-      decode_bin = TRUE;
-      config_file = argv[1];
-
-      break;
-    }
-
-    if (!strcmp (argv[0], "-e")) {
-      if (argc < 4 ) {
-        usage();
-      }
-
-      encode_docsis = TRUE;
-      config_file = argv[1];
-      key_file = argv[2];
-      output_file = argv[3];
-
-      break;
-    }
-
-    if (!strcmp (argv[0], "-m")) {
-      extension_string = argv[argc-1];
-      key_file = argv[argc-2];
-      encode_docsis = TRUE;
-
-      continue;
-    }
-
-    if (!strcmp (argv[0], "-p")) {
-      /* encode_docsis may already have been set via the "-m" option */
-      encode_docsis = 0;
-
-      argc--; argv++;
-
-      if (argc < 2 ) {
-        usage();
-      }
-
-      /* -p might be followed by -dialplan.  This is allowed for backwards
-       * compatibility */
-      if (!strcmp (argv[0], "-dialplan")) {
-        dialplan = 1;
-        argc--; argv++;
-      }
-
-      if (argc < 2 ) {
-        usage();
-      }
-
-      /* if -m has not already been specified, then we expect "<mta_cfg_file> <output_file>" */
-      if (extension_string == NULL) {
-        config_file = argv[0];
-        output_file = argv[1];
-      }
-
-      break;
-    }
-
-    /* no more recognisable options means that we've either finished parsing
-     * all arguments or else that the remaining arguments refer to a list of
-     * config files */
-    if ((argc && encode_docsis) || (argc && decode_bin)) {
-      break;
-    }
+  if (argc < 2 ) {
+	usage();
   }
+	mta_hash = getenv("MTAHASH");
+	while ((c = getopt (argc, argv, "d::e::fhH::mM:n::op:ow:?")) != -1) {
+		switch (c) {
+			case 'd':
+				if (optarg && strcmp("ialplan", optarg) == 0)
+					dialplan = 1;
+				else {
+					optarg = argv[optind++];
+					decode_bin = TRUE;
+					config_file = optarg;
+				}
+				break;
+			case 'e':
+				if (optarg && strcmp("u", optarg) == 0)  {
+					mta_hash = default_eu_hash;
+				} else {
+					optarg = argv[optind++];
+					encode_docsis = TRUE;
+					config_file = optarg;
+					if (!process_multiple) {
+						if (optind <= argc) {
+							key_file = argv[optind];
+							optind++;
+						}
+						if (optind <= argc) {
+							output_file = argv[optind];
+							optind++;
+						}
+					} else 
+						process_multiple = optind - 1;
+				}
+				break;
+			case 'f':
+				decode_format = NETSNMP_OID_OUTPUT_MODULE;
+				break;
+			case 'H':
+				if (!optarg)
+					if(argv[optind] && (*argv[optind] != '-'))
+						optarg = argv[optind++];
+					
+				mta_hash = (optarg ? optarg : default_na_hash);
+				break;
+			case 'm':
+				process_multiple = TRUE;
+				extension_string = argv[argc-1];
+				key_file = argv[argc-2];
+				break;
+			case 'M':
+				custom_mibs = optarg;
+				break;
+			case 'n':
+				if (optarg) {
+					if (strcmp("a", optarg) == 0) 
+						mta_hash = default_na_hash;
+					else if(strcmp("ohash", optarg) == 0)
+						nohash = 1;
+					else {
+						usage();
+					}
+				} else {
+					usage();
+				}
+				break;
+                                        
+			case 'o':
+				resolve_oids = 0;
+				break;
+			case 'p':
+				config_file = optarg;
+				if (!process_multiple) {
+					if (optind <= argc) {
+						output_file = argv[optind];
+						optind++;
+					}
+				} else 
+					process_multiple = optind - 1;
+				break;
+			case 'w':
+				mib_warning_level = atoi(optarg);
+				break;
+			case '?':
+			case 'h':
+				usage();
+				break;
+			default:
+				usage();
+		}
+	}
 
-  if (encode_docsis)
-    {
-      if ((kf = fopen (key_file, "r")) == NULL)
-        {
-          fprintf (stderr, "docsis: error: can't open keyfile %s\n", key_file);
-          exit (-5);
-        }
-      keylen = fread (key, sizeof (unsigned char), 64, kf);
-      while (keylen > 0 && (key[keylen - 1] == 10 || key[keylen - 1] == 13))
-        {
-          keylen--;		/* eliminate trailing \n or \r */
-        }
-      fclose(kf);
-    }
+	if(config_file == NULL) {
+		usage();
+		return 1;
+	}
+	
+	if (encode_docsis){
+		if ((kf = fopen(key_file, "r")) == NULL) {
+			fprintf (stderr, "docsis: error: can't open keyfile %s\n", key_file);
+			exit (-5);
+		}
+		keylen = fread (key, sizeof (unsigned char), 64, kf);
+		while (keylen > 0 && (key[keylen - 1] == 10 || key[keylen - 1] == 13)) {
+			keylen--;		/* eliminate trailing \n or \r */
+		}
+	}
 
-  init_global_symtable ();
-  setup_mib_flags(resolve_oids,custom_mibs);
+	init_global_symtable ();
+	setup_mib_flags(resolve_oids,custom_mibs);
 
-  if (decode_bin)
-  {
-      decode_file (config_file);
-      exit(0); // TODO: clean shutdown
-  }
+	if (decode_bin)
+	{
+		decode_file (config_file);
+		exit(0); // TODO: clean shutdown
+	}
 
-  if (extension_string) { /* encoding multiple files */
-	if (encode_docsis) {
-		/* encode argv[argc-3] to argv[0] */
-		for (i=0; i<argc-2; i++) {
-			if ( (output_file = get_output_name (argv[i], extension_string)) == NULL ) {
-				fprintf(stderr, "Cannot process input file %s, extension too short ?\n",argv[i] );
-				continue;
+	if (process_multiple) { /* encoding multiple files */
+		if (encode_docsis) {
+			/* encode argv[argc-3] to argv[2] */
+			for (i = process_multiple; i<argc - 2; i++)  {
+				if ( (output_file = get_output_name (argv[i], extension_string)) == NULL ) {
+					fprintf(stderr, "Cannot process input file %s, extension too short ?\n",argv[i] );
+					continue;
+				}
+
+				fprintf(stderr, "Processing input file %s: output to  %s\n",argv[i], output_file);
+				if (encode_one_file (argv[i], output_file, key, keylen, encode_docsis, mta_hash )) {
+					exit(2);
+				}
+				free (output_file);
+				output_file = NULL;
 			}
-
-			fprintf(stderr, "Processing input file %s: output to  %s\n",argv[i], output_file);
-			if (encode_one_file (argv[i], output_file, key, keylen, encode_docsis, hash)) {
-				exit(2);
+		} else {
+			/* encode argv[argc-2] to argv[3] */
+			for (i = process_multiple; i<argc - 2; i++)  {
+				if ( (output_file = get_output_name (argv[i], extension_string)) == NULL ) {
+					fprintf(stderr, "Cannot process input file %s, extension too short ?\n",argv[i] );
+					continue;
+				}
+				fprintf (stderr, "Processing input file %s: output to  %s\n",argv[i], output_file);
+				if (encode_one_file (argv[i], output_file, key, keylen, encode_docsis, mta_hash )) {
+					exit(2);
+				}
+				free (output_file);
+				output_file = NULL;
 			}
-			free (output_file);
-			output_file = NULL;
 		}
 	} else {
-		/* encode argv[argc-2] to argv[0] */
-		for (i=0; i<argc-1; i++) {
-			if ( (output_file = get_output_name (argv[i], extension_string)) == NULL ) {
-				fprintf(stderr, "Cannot process input file %s, extension too short ?\n",argv[i] );
-				continue;
-			}
-			fprintf (stderr, "Processing input file %s: output to  %s\n",argv[i], output_file);
-			if (encode_one_file (argv[i], output_file, key, keylen, encode_docsis, hash)) {
-				exit(2);
-			}
-			free (output_file);
-			output_file = NULL;
+		if (encode_one_file (config_file, output_file, key, keylen, encode_docsis, mta_hash )) {
+			exit(2);
 		}
+		/* encode argv[1] */
 	}
-  } else {
-	if (encode_one_file (config_file, output_file, key, keylen, encode_docsis, hash)) {
-		exit(2);
-	}
-	/* encode argv[1] */
-  }
-  free(global_symtable);
-  shutdown_mib();
-  return 0;
+	free(global_symtable);
+	shutdown_mib();
+	return 0;
 }
 
 int encode_one_file ( char *input_file, char *output_file,
-	 		unsigned char *key, unsigned int keylen, int encode_docsis, unsigned int hash)
+	 		unsigned char *key, unsigned int keylen, int encode_docsis, char *mta_hash )
 {
   int parse_result=0;
   unsigned int buflen;
@@ -513,7 +537,7 @@ int encode_one_file ( char *input_file, char *output_file,
 	return -1;
   }
 
-  parse_result = parse_config_file (input_file, &global_tlvtree_head );
+  parse_result = parse_config_file (input_file, &global_tlvtree_head, "" );
 
   if (parse_result || global_tlvtree_head == NULL)
     {
@@ -545,23 +569,21 @@ int encode_one_file ( char *input_file, char *output_file,
       buflen = add_cm_mic (buffer, buflen);
       buflen = add_cmts_mic (buffer, buflen, key, keylen);
       buflen = add_eod_and_pad (buffer, buflen);
+    } else {
+      if (dialplan == 1) {
+        printf("Adding PC20 dialplan from external file.\n");
+        buflen = add_dialplan (buffer, buflen);
+      }
+
+      if (mta_hash) {
+      /* add MTA-HASH */
+      
+        fprintf(stderr, "adding ConfigHash to MTA file.\n");
+        buflen = add_mta_hash (buffer, buflen);
+       }
     }
 
-  if (dialplan == 1) {
-    printf("Adding PC20 dialplan from external file.\n");
-    buflen = add_dialplan (buffer, buflen);
-  }
-
-  if (hash == 1) {
-    printf("Adding NA ConfigHash to MTA file.\n");
-    buflen = add_mta_hash (buffer, buflen, hash);
-  }
-  if (hash == 2) {
-    printf("Adding EU ConfigHash to MTA file.\n");
-    buflen = add_mta_hash (buffer, buflen, hash);
-  }
-
-  fprintf (stdout, "Final content of config file:\n");
+  fprintf (stderr, "Final content of config file:\n");
 
   decode_main_aggregate (buffer, buflen);
   if (!strcmp (output_file, "-"))
@@ -573,11 +595,7 @@ int encode_one_file ( char *input_file, char *output_file,
       fprintf (stderr, "docsis: error: can't open output file %s\n", output_file);
       return -2;
     }
-  if (fwrite (buffer, 1, buflen, of) != buflen)
-    {
-      fprintf (stderr, "docsis: error: can't write to output file %s\n", output_file);
-      return -2;
-    }
+  fwrite (buffer, sizeof (unsigned char), buflen, of);
   fclose (of);
   free(buffer);
   return 0;
@@ -630,8 +648,7 @@ setup_mib_flags(int resolve_oids, char *custom_mibs) {
 #ifdef DEBUG
 /*  snmp_set_mib_warnings (2); */
 #endif /* DEBUG  */
-/* We do not want warning for normal users. Should be set with an argument on the CLI maybe?
- * snmp_set_mib_warnings (1); */
+snmp_set_mib_warnings (mib_warning_level);
 
   if (custom_mibs)
     {
@@ -643,21 +660,12 @@ setup_mib_flags(int resolve_oids, char *custom_mibs) {
      setenv ("MIBS", "ALL", 1);
     }
 
-  if (!resolve_oids) {
-    if (!netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID, NETSNMP_OID_OUTPUT_NUMERIC)) {
-      netsnmp_ds_toggle_boolean (NETSNMP_DS_LIBRARY_ID, NETSNMP_OID_OUTPUT_NUMERIC);
-    }
-  }
-
-  /* DOCSIS vendors are notorious for supplying MIBs with invalid syntax */
-  netsnmp_ds_set_boolean(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_MIB_PARSE_LABEL, 1);
-
 #ifdef HAVE_NETSNMP_INIT_MIB
   netsnmp_init_mib ();
 #else
   init_mib ();
 #endif
-  
+
   if (!netsnmp_ds_get_boolean
       (NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_PRINT_NUMERIC_OIDS))
     {

--- a/src/docsis.h
+++ b/src/docsis.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL, office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -94,11 +95,13 @@ void hmac_md5 (unsigned char *text, int text_len, unsigned char *key,
 void md5_print_digest (unsigned char *digest);
 int init_global_symtable (void);
 unsigned int tlvtreelen  (struct tlv *tlv);
-int parse_config_file (char *file, struct tlv **parse_tree_result);
+int parse_config_file (char *file, struct tlv **parse_tree_result, char *mtahash);
 int yylex (void);
 void decode_file (char *file);
 int encode_one_file (char *input_file, char *output_file,
-		       unsigned char *key, unsigned int keylen, int encode_docsis, unsigned int hash);
+		       unsigned char *key, unsigned int keylen, int encode_docsis, char *mta_hash);
 char *get_output_name (char *input_path, char *new_extension);
+
+extern unsigned int decode_format;
 
 #endif /* __DOCSIS_H */

--- a/src/docsis_common.h
+++ b/src/docsis_common.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_decode.c
+++ b/src/docsis_decode.c
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_decode.h
+++ b/src/docsis_decode.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_encode.c
+++ b/src/docsis_encode.c
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001,2005 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_encode.h
+++ b/src/docsis_encode.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_globals.h
+++ b/src/docsis_globals.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_lex.l
+++ b/src/docsis_lex.l
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001,2005 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL, office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -69,9 +70,9 @@ char *tsave;
 ([0-9]+\.){3}[0-9]+\/[0-9]+	 	{ TSAVE(yytext);yylval.strval=tsave; return T_IP_IP6_PORT; }
 ([0-9A-Fa-f][0-9A-Fa-f]:){5}[0-9A-Fa-f][0-9A-Fa-f]  { TSAVE(yytext);yylval.strval=tsave; return T_MAC; 			       }
 
-(\.{1})*([A-Za-z0-9_-]+\.)+[A-Za-z0-9]+	{ TSAVE(yytext);yylval.strval=tsave; return T_LABEL_OID; }
-(\.{1})*([A-Za-z0-9_-]+\.)+'[\[A-Za-z0-9@,:_\-\.\]]+'	{ TSAVE(yytext);yylval.strval=tsave; return T_LABEL_OID; }
-(\.{1})*([A-Za-z0-9_-]+\.)+((\"{1})*[A-Za-z0-9,:_\-\.]+(\"{1})*)+	{ TSAVE(yytext);yylval.strval=tsave; return T_LABEL_OID; }
+(\.{1})*([A-Za-z0-9_:-]+\.)+[A-Za-z0-9]+	{ TSAVE(yytext);yylval.strval=tsave; return T_LABEL_OID; }
+(\.{1})*([A-Za-z0-9_:-]+\.)+'[\[A-Za-z0-9@,:_\-\.\]]+'	{ TSAVE(yytext);yylval.strval=tsave; return T_LABEL_OID; }
+(\.{1})*([A-Za-z0-9_:-]+\.)+((\"{1})*[A-Za-z0-9,:_\-\.]+(\"{1})*)+	{ TSAVE(yytext);yylval.strval=tsave; return T_LABEL_OID; }
 ([0-9]+:){3}[0-9]+\.[0-9]+	{ TSAVE(yytext);yylval.strval=tsave; return T_TIMETICKS; }
 [Mm][Aa][Ii][Nn]        { yylval.strval=yytext;return T_MAIN; }
 SnmpWriteControl	{ yylval.symptr=find_symbol_by_name(yytext);return T_IDENT_SNMPW;   }
@@ -146,6 +147,7 @@ TlvType			{ return T_TLV_TYPE;		}
 <COMMENT>\n	{ line ++; }
 <COMMENT>.
 <COMMENT>\/[*]+	{ fprintf(stderr, "line %d: comment-in-comment not supported", line) ; }
+\/\/[^\n]* { COMMENT; }
 <COMMENT>[*]+\/	{ BEGIN 0; }
 
 [0-9]+	 { yylval.intval=atoi(yytext);return T_INTEGER; }

--- a/src/docsis_snmp.c
+++ b/src/docsis_snmp.c
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,6 +26,8 @@
 #include "docsis_decode.h"
 
 extern unsigned int line;	/* from a.l */
+
+unsigned int decode_format = NETSNMP_OID_OUTPUT_SUFFIX;
 
 #define PACKET_LENGTH (8 * 1024)
 
@@ -339,12 +342,7 @@ decode_vbind (unsigned char *data, unsigned int vb_len)
 
   netsnmp_ds_set_int (NETSNMP_DS_LIBRARY_ID,
 			      NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
-			      NETSNMP_OID_OUTPUT_SUFFIX);
-
-  if (netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID, NETSNMP_OID_OUTPUT_NUMERIC)) {
-        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
-                                                  NETSNMP_OID_OUTPUT_NUMERIC);
-  }
+			      decode_format);
 
   snprint_objid (outbuf, 1023, vp->name, vp->name_length);
 
@@ -359,12 +357,12 @@ decode_vbind (unsigned char *data, unsigned int vb_len)
 	  netsnmp_ds_set_int (NETSNMP_DS_LIBRARY_ID,
 			      NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
 			      NETSNMP_OID_OUTPUT_FULL);
-	  memset (outbuf, 0, 1024);
+	  memset (outbuf, 0, 16384);
 	  snprint_objid (outbuf, 1023, vp->name, vp->name_length);
 	  /* Go back to suffix-mode for better readability */
 	  netsnmp_ds_set_int (NETSNMP_DS_LIBRARY_ID,
 			      NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
-			      NETSNMP_OID_OUTPUT_SUFFIX);
+			      decode_format);
 	}
     }
 

--- a/src/docsis_snmp.h
+++ b/src/docsis_snmp.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002 Evvolve Media SRL, office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -47,6 +48,8 @@ unsigned char *_docsis_snmp_build_var_op(unsigned char * data,
                   unsigned char * var_val, size_t * listlength);
 
 unsigned char *_docsis_asn_build_sequence(unsigned char * data, size_t * datalength, unsigned char type, size_t length);
+
+extern unsigned int decode_format;
 
 #endif /* _DOCSIS_SNMP_H */
 

--- a/src/docsis_symtable.h
+++ b/src/docsis_symtable.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002,2003,2004,2005 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/docsis_yy.y
+++ b/src/docsis_yy.y
@@ -38,6 +38,7 @@ extern unsigned int line; 	/* current line number, defined in a.l */
 extern struct tlv *global_tlvtree_head; /* Global list of all config TLVs */
 extern symbol_type *global_symtable;
 extern FILE *yyin;
+extern int yy_scan_string(const char *);
 
 struct tlv *_my_tlvtree_head;
 
@@ -627,15 +628,21 @@ unsigned int tlvtreelen (struct tlv *tlv)
    return current_size;
 }
 
-int parse_config_file ( char *file, struct tlv **parse_tree_result )
+int parse_config_file ( char *file, struct tlv **parse_tree_result, char *mtahash )
 {
   FILE *cf;
   int rval;
+  line = 1;
 
   if ( !strcmp(file, "-") )
   {
 	cf = stdin;
   }
+  else if ( strcmp(mtahash, "") ) {
+            //if cf is not set the encoder runs into a "segmentation fault"!
+    cf = stdin;
+    yy_scan_string(mtahash);
+    } 
   else if ( (cf = fopen ( file, "r" )) == NULL )
   {
 	fprintf (stderr, "docsis: Can't open input file %s\n", file );

--- a/src/ethermac.c
+++ b/src/ethermac.c
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ethermac.h
+++ b/src/ethermac.h
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002 Evvolve Media SRL,office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hmac_md5.c
+++ b/src/hmac_md5.c
@@ -3,6 +3,7 @@
  *  Copyright (c) 2001 Cornel Ciocirlan, ctrl@users.sourceforge.net.
  *  Copyright (c) 2002, 2003 Evvolve Media SRL, office@evvolve.com
  *  Copyright (c) 2014 - 2015 Adrian Simionov, daniel.simionov@gmail.com
+ *  Copyright (c) 2015 - 2016 Lukasz Sierzega, xarafaxz@gmail.com
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
	* Feature: Allowing use MIB-MODULE-NAME:: MODULE-NAME-SPACE:: et cetera in SnmpMibObject TLV which i strongly recommend
		that resolve problems with mibs name colision, for example: PacketCable/EuroPacketCable, Motorola/Compal enterprise mibs.
		you can use "-f" switch to include MIB-MODULE-NAME:: prefixes in config dump
	* Feature: Allowing use C-style inline comments "//"
	* Feature: Allow use custom mib for packetcable hash signing becasuse "-eu" / EuroPacketCable and "-na" PacketCable are not enough
		use "-H [MIB]" switch to set custom hash mib.
	* Attempt to cleanup option parsing mess. Now option parsing is getopt based. However due to preserving option compatibility it is create another mess. Just slighty lesser, i think.