### PR TITLE
removed translation of backslashes to spaces. in favor of allowing them.

### DIFF
--- a/src/docsis_lex.l
+++ b/src/docsis_lex.l
@@ -124,7 +124,7 @@ TlvType			{ return T_TLV_TYPE;		}
 <STRING>\\ 	{
 			if (strsize<2048)
 			{
-				*str++ = ' ';
+				*str++ = '\\';
 				strsize++;
 			} else {
 			  fprintf(stderr, "line %d: string too long (max 2048 characters)\n",line); exit(-1);


### PR DESCRIPTION
I see no reason if the lexer encounters a backslash to translate it to a space. it may very well be that I could have simply removed this entry in the lexer. but I don't really know